### PR TITLE
fix: use a valid app name

### DIFF
--- a/bridging-tutorial-website/docs/getting-started.mdx
+++ b/bridging-tutorial-website/docs/getting-started.mdx
@@ -61,7 +61,7 @@ Make sure you have correct [environment setup](https://reactnative.dev/docs/envi
 To bootstrap the project run:
 
 ```sh
-npx react-native init sample-app
+npx react-native init SampleApp
 ```
 
 ### 3. [RECOMMENDED] Migrate to Yarn 3


### PR DESCRIPTION
When trying to follow the tutorial, I got the following error when trying to create the sample app with the suggested command:
```
❯ npx react-native init sample-app
Need to install the following packages:
  react-native
Ok to proceed? (y) y
error "sample-app" is not a valid name for a project. Please use a valid identifier name (alphanumeric).
Error: "sample-app" is not a valid name for a project. Please use a valid identifier name (alphanumeric).
```

`SampleApp` is valid however