### PR TITLE
fix: android codegen command type

### DIFF
--- a/bridging-tutorial-website/docs/getting-started.mdx
+++ b/bridging-tutorial-website/docs/getting-started.mdx
@@ -156,7 +156,7 @@ module.exports = {
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-+   "codegen:android": "./android/gradlew -p android generateArtifactsFromSchema",
++   "codegen:android": "./android/gradlew -p android generateCodegenArtifactsFromSchema",
 +   "codegen:ios": "node node_modules/react-native/scripts/generate-codegen-artifacts.js --path . --outputPath ./ios"
   },
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "codegen:android": "./android/gradlew -p android generateArtifactsFromSchema",
+    "codegen:android": "./android/gradlew -p android generateCodegenArtifactsFromSchema",
     "codegen:ios": "node node_modules/react-native/scripts/generate-codegen-artifacts.js --path . --outputPath ./ios"
   },
   "dependencies": {


### PR DESCRIPTION
I was following the tutorial and reached [here](https://mateusz1913.github.io/rnbridgingtutorial/docs/guides/app-info-module/js-spec) and while running `yarn codegen:android`. I got the following error:

`Task 'generateArtifactsFromSchema' not found in root project 'SampleApp'.`

I searched a bit and I guess it was a typo of `generateArtifactsFromSchema` instead of `generateCodegenArtifactsFromSchema`
