### PR TITLE
fix: escape the backslash

### DIFF
--- a/bridging-tutorial-website/docs/guides/_package-structure-boilerplate.mdx
+++ b/bridging-tutorial-website/docs/guides/_package-structure-boilerplate.mdx
@@ -91,7 +91,7 @@ Pod::Spec.new do |s|
     s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
     # XCode flags for new arch
     s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+      "HEADER_SEARCH_PATHS" => "\\\"$(PODS_ROOT)/boost\\\"",
       "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
       "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
       "DEFINES_MODULE" => "YES",

--- a/bridging-tutorial-website/docs/guides/range-slider-view/_ios-add-library-in-podspec.mdx
+++ b/bridging-tutorial-website/docs/guides/range-slider-view/_ios-add-library-in-podspec.mdx
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
     s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
     # XCode flags for new arch
     s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+      "HEADER_SEARCH_PATHS" => "\\\"$(PODS_ROOT)/boost\\\"",
       "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
       "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
       "DEFINES_MODULE" => "YES",


### PR DESCRIPTION
## Summary

I guess this fixes #19 
I believe the first backslash was for the double quotes so for the backslash to be shown it need to be escaped too, so it should be like this:
`"HEADER_SEARCH_PATHS" => "\\\"$(PODS_ROOT)/boost\\\"",`
instead of 
`"HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",`