### PR TITLE
fix(#21): setup fixes

### DIFF
--- a/app-info-package-classic/AppInfoPackageClassic.podspec
+++ b/app-info-package-classic/AppInfoPackageClassic.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name            = "AppInfoPackageClassic"
@@ -16,16 +16,9 @@ Pod::Spec.new do |s|
   s.source          = { :git => package["repository"], :tag => "#{s.version}" }
 
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "React-Core"
 
-  if fabric_enabled
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  if new_arch_enabled
+    s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "AppInfoPackageClassic-Swift.h",
       # This is handy when we want to detect if new arch is enabled in Swift code
@@ -37,16 +30,16 @@ Pod::Spec.new do |s|
       # #endif
       "OTHER_SWIFT_FLAGS" => "-DAPP_INFO_PACKAGE_CLASSIC_NEW_ARCH_ENABLED"
     }
-
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
   else
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "AppInfoPackageClassic-Swift.h"
     }
   end
+  
+  # Install all React Native dependencies (RN >= 0.71 must be used)
+  #
+  # check source code for more context
+  # https://github.com/facebook/react-native/blob/0.71-stable/scripts/react_native_pods.rb#L172#L180
+  install_modules_dependencies(s)
 end

--- a/bridging-tutorial-website/docs/getting-started.mdx
+++ b/bridging-tutorial-website/docs/getting-started.mdx
@@ -166,7 +166,51 @@ First change to `"android"` command is decreasing build times on Android - it wi
 
 Those other commands - `"codegen:android"` & `"codegen:ios"` - are commands that invoke React Native Codegen and generate specification for your native code.
 
-### 6. Switch the app to ["New Architecture"](https://reactnative.dev/docs/the-new-architecture/landing-page)
+### 6. If you'll use Kotlin for Android development, add Kotlin to your test project, otherwise skip this step
+
+```diff title="android/build.gradle"
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    ext {
+        buildToolsVersion = "33.0.0"
+        minSdkVersion = 21
+        compileSdkVersion = 33
+        targetSdkVersion = 33
++       kotlinVersion = "1.6.10"
+
+        // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
+        ndkVersion = "23.1.7779620"
+    }
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:7.3.1")
+        classpath("com.facebook.react:react-native-gradle-plugin")
++       classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+    }
+}
+```
+
+```diff title="android/app/build.gradle"
+apply plugin: "com.android.application"
++apply plugin: "kotlin-android"
+apply plugin: "com.facebook.react"
+
+import com.android.build.OutputFile
+
+// ...
+```
+
+After that, verify if everything works by building your project
+
+```sh
+yarn android
+```
+
+### 7. Switch the app to ["New Architecture"](https://reactnative.dev/docs/the-new-architecture/landing-page)
 
 "New Architecture" is the future and that's why it will be used throughout this tutorial. Guides will showcase how to write the code that supports both old and new arch. However, because new arch setups are more complex, you'll benefit from testing the native code you wrote with TurboModules and Fabric and the backward compatibility layer will make it just work on the old architecture.
 
@@ -180,7 +224,17 @@ To enable "New Architecture" on iOS:
 - add `ENV['RCT_NEW_ARCH_ENABLED'] = "1"` after `require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'` - this will set the `RCT_NEW_ARCH_ENABLED` to `1` on each `pod install` run, so you'll not need to set that env before running installing the Pods
 - run `npx pod-install` to install "New Architecture" Pods
 
-### 7. [OPTIONAL] Navigation setup
+After that, verify if everything works by building your project
+
+```sh
+yarn ios
+```
+
+```sh
+yarn android
+```
+
+### 8. [OPTIONAL] Navigation setup
 
 If you want to use the same app for different guides, you'll likely need some navigation to navigate between them - use the navigation library of your choice, just make sure it supports "New Architecture"
 

--- a/bridging-tutorial-website/docs/guides/_android-turbo-package-boilerplate.mdx
+++ b/bridging-tutorial-website/docs/guides/_android-turbo-package-boilerplate.mdx
@@ -1,12 +1,8 @@
 import CodeBlock from '@theme/CodeBlock';
 
-<h4>
-<code>{props.packageClass}.{props.language === 'java' ? 'java' : 'kt'}</code>
-</h4>
-
 <p>
-The last thing we need to do is to export <code>{props.moduleClass}</code> in the <code>TurboReactPackage</code> instance.
-Let's go to <code>{props.packageClass}.{props.language === 'java' ? 'java' : 'kt'}</code> and add our new module.
+To make the codegen working on Android, the instance of <code>TurboReactPackage</code> needs to be found by the React Native CLI.
+So let's fill the minimal boilerplate to make it possible to link the package.
 </p>
 
 <CodeBlock language={props.language} title={`android/src/main/java/com/${props.namespace}/${props.packageClass}.${props.language === 'java' ? 'java' : 'kt'}`}>
@@ -18,14 +14,8 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.module.model.ReactModuleInfo;
 import com.facebook.react.module.model.ReactModuleInfoProvider;
-import com.facebook.react.turbomodule.core.interfaces.TurboModule;
-${props.viewManagerClass ? `// highlight-start
-import com.facebook.react.uimanager.ViewManager;\n
-import java.util.Arrays;
-// highlight-end` : ``}
-import java.util.HashMap;${props.viewManagerClass ? `\n// highlight-start
-import java.util.List;
-// highlight-end` : ``}
+import com.facebook.react.turbomodule.core.interfaces.TurboModule;\n
+import java.util.HashMap;
 import java.util.Map;\n
 public class ${props.packageClass} extends TurboReactPackage {
     /**
@@ -34,12 +24,7 @@ public class ${props.packageClass} extends TurboReactPackage {
     @Override
     @Nullable
     public NativeModule getModule(String name, ReactApplicationContext reactContext) {
-        ${props.moduleClass ? `// highlight-start
-        if (name.equals(${props.moduleClass}.NAME)) {
-            return new ${props.moduleClass}(reactContext);
-        }
         return null;
-// highlight-end` : `return null;`}
     }\n
     /**
      * Declare info about exported modules
@@ -49,9 +34,7 @@ public class ${props.packageClass} extends TurboReactPackage {
         /**
          * Here declare the array of exported modules
          */
-        Class<? extends NativeModule>[] moduleList = new Class[] {${props.moduleClass ? `\n// highlight-start
-            ${props.moduleClass}.class
-            // highlight-end` : ``}
+        Class<? extends NativeModule>[] moduleList = new Class[] {
         };
         final Map<String, ReactModuleInfo> reactModuleInfoMap = new HashMap<>();
         /**
@@ -78,15 +61,7 @@ public class ${props.packageClass} extends TurboReactPackage {
                 return reactModuleInfoMap;
             }
         };
-    }${props.viewManagerClass ? `\n\n// highlight-start
-    @Override
-    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-        /**
-        * Here declare the list of exported native components
-        */
-        return Arrays.<ViewManager>asList(new ${props.viewManagerClass}());
     }
-    // highlight-end` : ``}
 }` : `package com.${props.namespace}\n
 import com.facebook.react.TurboReactPackage
 import com.facebook.react.bridge.NativeModule
@@ -100,12 +75,7 @@ class ${props.packageClass} : TurboReactPackage() {
      * Initialize and export modules based on the name of the required module
      */
     override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
-        ${props.moduleClass ? `// highlight-start
-        return when (name) {
-            ${props.moduleClass}.NAME -> ${props.moduleClass}(reactContext)
-            else -> null
-        }
-        // highlight-end` : `return null`}
+        return null
     }\n
     /**
      * Declare info about exported modules
@@ -114,9 +84,7 @@ class ${props.packageClass} : TurboReactPackage() {
         /**
          * Here declare the array of exported modules
          */
-        val moduleList: Array<Class<out NativeModule?>> = arrayOf(${props.moduleClass ? `\n// highlight-start
-            ${props.moduleClass}::class.java
-            // highlight-end` : ``}
+        val moduleList: Array<Class<out NativeModule?>> = arrayOf(
         )
         val reactModuleInfoMap: MutableMap<String, ReactModuleInfo> = HashMap()
         /**
@@ -136,24 +104,6 @@ class ${props.packageClass} : TurboReactPackage() {
                 )
         }
         return ReactModuleInfoProvider { reactModuleInfoMap }
-    }${props.viewManagerClass ? `\n\n// highlight-start
-    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
-        /**
-        * Here declare the list of exported native components
-        */
-        return listOf(${props.viewManagerClass}())
     }
-    // highlight-end` : ``}
 }`}
 </CodeBlock>
-
-<div>
-  {props.moduleClass ? <div>
-    <p>To export the module, as the first step, we need to return it from <code>getModule</code> method inside <code>{props.packageClass}</code>,
-    if it's requested (the method takes name as a parameter and makes decision which module should be served).</p>
-    <p>The second step is to implement <code>getReactModuleInfoProvider</code> method, where the module is injected to the info provider instance.</p>
-  </div> : props.viewManagerClass ? <p>
-    Here the most important bit is <code>createViewManagers</code> method, which returns collection of view manager classes.
-    Because our package exports only a single view, we register one-element list, with <code>{props.viewManagerClass}</code> class.
-  </p> : null}
-</div>

--- a/bridging-tutorial-website/docs/guides/_package-structure-boilerplate.mdx
+++ b/bridging-tutorial-website/docs/guides/_package-structure-boilerplate.mdx
@@ -69,7 +69,7 @@ Next, let's create <code>{props.packageNameUpperCamelCase}.podspec</code>, the "
 require "json"\n
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))\n
 # Detect if new arch is enabled
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'\n
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'\n
 Pod::Spec.new do |s|
   s.name            = "${props.packageNameUpperCamelCase}"
   s.version         = package["version"]
@@ -81,19 +81,9 @@ Pod::Spec.new do |s|
   s.author          = package["author"]
   s.source          = { :git => package["repository"], :tag => "#{s.version}" }\n
   # This is crucial - declare which files will be included in the package (similar to "files" field in \`package.json\`)
-  s.source_files    = "ios/**/*.{h,m,mm,swift}"
-  # Declare dependency (similar to entries under "dependencies" field in \`package.json\`)
-  s.dependency "React-Core"\n
-  # More configuration depending on new or old arch used
-  if fabric_enabled
-    # Some compiler flags
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'\n
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    # XCode flags for new arch
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  s.source_files    = "ios/**/*.{h,m,mm,swift}"\n
+  if new_arch_enabled
+    s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "${props.packageNameUpperCamelCase}-Swift.h",
       # This is handy when we want to detect if new arch is enabled in Swift code
@@ -104,20 +94,18 @@ Pod::Spec.new do |s|
       # // do sth when old arch is enabled
       # #endif
       "OTHER_SWIFT_FLAGS" => "-D${props.packageNameUpperCase}_NEW_ARCH_ENABLED"
-    }\n
-    # Dependencies only for new arch${props.isFabricComponent ? '\n    s.dependency "React-RCTFabric"' : ''}
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+    }
   else
-    # XCode flags for old arch
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "${props.packageNameUpperCamelCase}-Swift.h"
     }
-  end
+  end\n
+  # Install all React Native dependencies (RN >= 0.71 must be used)
+  #
+  # check source code for more context
+  # https://github.com/facebook/react-native/blob/0.71-stable/scripts/react_native_pods.rb#L172#L180
+  install_modules_dependencies(s)
 end`}
 </CodeBlock>
 
@@ -305,7 +293,7 @@ def reactNativeRootDir = resolveReactNativeDirectory()\n
 def reactProperties = new Properties()
 file("$reactNativeRootDir/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }\n
 def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
-def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.startsWith("0.0.0-") ? 1000 : REACT_NATIVE_VERSION.split("\\.")[1].toInteger()\n
+def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.startsWith("0.0.0-") ? 1000 : REACT_NATIVE_VERSION.split("\\\\.")[1].toInteger()\n
 project.ext.shouldConsumeReactNativeFromMavenCentral = { ->
     return REACT_NATIVE_MINOR_VERSION >= 71
 }`}
@@ -356,7 +344,7 @@ val REACT_NATIVE_VERSION: String = reactProperties.getProperty("VERSION_NAME")
 val REACT_NATIVE_MINOR_VERSION = if (REACT_NATIVE_VERSION.startsWith("0.0.0-")) {
     1000
 } else {
-    REACT_NATIVE_VERSION.split(Regex("\\."))[1].toInt()
+    REACT_NATIVE_VERSION.split(Regex("\\\\."))[1].toInt()
 }\n
 val shouldConsumeReactNativeFromMavenCentral by extra {
     fun(): Boolean {

--- a/bridging-tutorial-website/docs/guides/app-info-module/setup.mdx
+++ b/bridging-tutorial-website/docs/guides/app-info-module/setup.mdx
@@ -7,6 +7,7 @@ title: Module boilerplate
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AndroidTurboPackageBoilerplate from '../_android-turbo-package-boilerplate.mdx';
 import LinkPackage from '../_link-package.mdx';
 import PackageStructureBoilerplate from '../_package-structure-boilerplate.mdx';
 
@@ -60,6 +61,12 @@ For Android implementation, create:
 - `android/src/newarch/java/com/appinfopackage/AppInfoModule.kt`
 - `android/src/oldarch/java/com/appinfopackage/AppInfoModule.kt`
 
+<AndroidTurboPackageBoilerplate
+  language="kotlin"
+  namespace="appinfopackage"
+  packageClass="AppInfoTurboPackage"
+/>
+
 </TabItem>
 <TabItem value="java" label="Java">
 
@@ -67,6 +74,12 @@ For Android implementation, create:
 - `android/src/main/java/com/appinfopackage/AppInfoTurboPackage.java`
 - `android/src/newarch/java/com/appinfopackage/AppInfoModule.java`
 - `android/src/oldarch/java/com/appinfopackage/AppInfoModule.java`
+
+<AndroidTurboPackageBoilerplate
+  language="java"
+  namespace="appinfopackage"
+  packageClass="AppInfoTurboPackage"
+/>
 
 </TabItem>
 </Tabs>

--- a/bridging-tutorial-website/docs/guides/conic-gradient-view/_android-java-view.mdx
+++ b/bridging-tutorial-website/docs/guides/conic-gradient-view/_android-java-view.mdx
@@ -5,7 +5,7 @@ Let's start by declaring the custom view that will extend `ReactViewGroup` (the 
 ```java title="android/src/newarch/java/com/conicgradientpackage/ConicGradientView.java"
 package com.conicgradientpackage;
 
-import android.graphics.Color;
+import android.graphics.*;
 
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.ReactContext;

--- a/bridging-tutorial-website/docs/guides/conic-gradient-view/intro.mdx
+++ b/bridging-tutorial-website/docs/guides/conic-gradient-view/intro.mdx
@@ -28,4 +28,4 @@ As a user, I want to see the gradient background for the screen.
 
 <Result />
 
-Can't wait? Let's set up [module boilerplate](./setup).
+Can't wait? Let's set up [view boilerplate](./setup).

--- a/bridging-tutorial-website/docs/guides/conic-gradient-view/setup.mdx
+++ b/bridging-tutorial-website/docs/guides/conic-gradient-view/setup.mdx
@@ -7,6 +7,7 @@ title: View boilerplate
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AndroidTurboPackageBoilerplate from '../_android-turbo-package-boilerplate.mdx';
 import LinkPackage from '../_link-package.mdx';
 import PackageStructureBoilerplate from '../_package-structure-boilerplate.mdx';
 
@@ -55,6 +56,12 @@ For Android implementation, create:
 - `android/src/newarch/java/com/conicgradientpackage/ConicGradientViewManager.kt`
 - `android/src/oldarch/java/com/conicgradientpackage/ConicGradientViewManager.kt`
 
+<AndroidTurboPackageBoilerplate
+  language="kotlin"
+  namespace="conicgradientpackage"
+  packageClass="ConicGradientTurboPackage"
+/>
+
 </TabItem>
 <TabItem value="java" label="Java">
 
@@ -62,6 +69,12 @@ For Android implementation, create:
 - `android/src/main/java/com/conicgradientpackage/ConicGradientTurboPackage.java`
 - `android/src/newarch/java/com/conicgradientpackage/ConicGradientViewManager.java`
 - `android/src/oldarch/java/com/conicgradientpackage/ConicGradientViewManager.java`
+
+<AndroidTurboPackageBoilerplate
+  language="java"
+  namespace="conicgradientpackage"
+  packageClass="ConicGradientTurboPackage"
+/>
 
 </TabItem>
 </Tabs>

--- a/bridging-tutorial-website/docs/guides/range-slider-view/_ios-add-library-in-podspec.mdx
+++ b/bridging-tutorial-website/docs/guides/range-slider-view/_ios-add-library-in-podspec.mdx
@@ -12,7 +12,7 @@ require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 # Detect if new arch is enabled
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name            = "RangeSliderPackage"
@@ -27,22 +27,12 @@ Pod::Spec.new do |s|
 
   # This is crucial - declare which files will be included in the package (similar to "files" field in `package.json`)
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
-  # Declare dependency (similar to entries under "dependencies" field in `package.json`)
-  s.dependency "React-Core"
-+
+
++ # Declare dependency (similar to entries under "dependencies" field in `package.json`)
 + s.dependency 'RangeUISlider', '~> 3.0'
 
-  # More configuration depending on new or old arch used
-  if fabric_enabled
-    # Some compiler flags
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    # XCode flags for new arch
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  if new_arch_enabled
+    s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "RangeSliderPackage-Swift.h",
       # This is handy when we want to detect if new arch is enabled in Swift code
@@ -54,20 +44,18 @@ Pod::Spec.new do |s|
       # #endif
       "OTHER_SWIFT_FLAGS" => "-DRANGE_SLIDER_PACKAGE_NEW_ARCH_ENABLED"
     }
-
-    # Dependencies only for new arch
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
   else
-    # XCode flags for old arch
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "RangeSliderPackage-Swift.h"
     }
   end
+
+  # Install all React Native dependencies (RN >= 0.71 must be used)
+  #
+  # check source code for more context
+  # https://github.com/facebook/react-native/blob/0.71-stable/scripts/react_native_pods.rb#L172#L180
+  install_modules_dependencies(s)
 end
 ```
 

--- a/bridging-tutorial-website/docs/guides/range-slider-view/intro.mdx
+++ b/bridging-tutorial-website/docs/guides/range-slider-view/intro.mdx
@@ -33,4 +33,4 @@ As a user, I want to use a range slider, to adjust the range filter.
 
 <Result />
 
-Can't wait? Let's set up [module boilerplate](./setup).
+Can't wait? Let's set up [view boilerplate](./setup).

--- a/bridging-tutorial-website/docs/guides/range-slider-view/setup.mdx
+++ b/bridging-tutorial-website/docs/guides/range-slider-view/setup.mdx
@@ -7,6 +7,7 @@ title: View boilerplate
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AndroidTurboPackageBoilerplate from '../_android-turbo-package-boilerplate.mdx';
 import LinkPackage from '../_link-package.mdx';
 import PackageStructureBoilerplate from '../_package-structure-boilerplate.mdx';
 
@@ -70,6 +71,12 @@ For Android implementation, create:
 - `android/src/newarch/java/com/rangesliderpackage/RangeSliderViewManager.kt`
 - `android/src/oldarch/java/com/rangesliderpackage/RangeSliderViewManager.kt`
 
+<AndroidTurboPackageBoilerplate
+  language="kotlin"
+  namespace="rangesliderpackage"
+  packageClass="RangeSliderTurboPackage"
+/>
+
 </TabItem>
 <TabItem value="java" label="Java">
 
@@ -80,6 +87,12 @@ For Android implementation, create:
 - `android/src/main/java/com/rangesliderpackage/OnRangeSliderViewValueChangeEvent.java`
 - `android/src/newarch/java/com/rangesliderpackage/RangeSliderViewManager.java`
 - `android/src/oldarch/java/com/rangesliderpackage/RangeSliderViewManager.java`
+
+<AndroidTurboPackageBoilerplate
+  language="java"
+  namespace="rangesliderpackage"
+  packageClass="RangeSliderTurboPackage"
+/>
 
 </TabItem>
 </Tabs>

--- a/bridging-tutorial-website/docs/guides/save-file-picker-module/setup.mdx
+++ b/bridging-tutorial-website/docs/guides/save-file-picker-module/setup.mdx
@@ -7,6 +7,7 @@ title: Module boilerplate
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AndroidTurboPackageBoilerplate from '../_android-turbo-package-boilerplate.mdx';
 import LinkPackage from '../_link-package.mdx';
 import PackageStructureBoilerplate from '../_package-structure-boilerplate.mdx';
 
@@ -60,6 +61,12 @@ For Android implementation, create:
 - `android/src/newarch/java/com/savefilepickerpackage/SaveFilePickerModule.kt`
 - `android/src/oldarch/java/com/savefilepickerpackage/SaveFilePickerModule.kt`
 
+<AndroidTurboPackageBoilerplate
+  language="kotlin"
+  namespace="savefilepickerpackage"
+  packageClass="SaveFilePickerTurboPackage"
+/>
+
 </TabItem>
 <TabItem value="java" label="Java">
 
@@ -67,6 +74,12 @@ For Android implementation, create:
 - `android/src/main/java/com/savefilepickerpackage/SaveFilePickerTurboPackage.java`
 - `android/src/newarch/java/com/savefilepickerpackage/SaveFilePickerModule.java`
 - `android/src/oldarch/java/com/savefilepickerpackage/SaveFilePickerModule.java`
+
+<AndroidTurboPackageBoilerplate
+  language="java"
+  namespace="savefilepickerpackage"
+  packageClass="SaveFilePickerTurboPackage"
+/>
 
 </TabItem>
 </Tabs>

--- a/conic-gradient-package-classic/ConicGradientPackageClassic.podspec
+++ b/conic-gradient-package-classic/ConicGradientPackageClassic.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name            = "ConicGradientPackageClassic"
@@ -16,16 +16,9 @@ Pod::Spec.new do |s|
   s.source          = { :git => package["repository"], :tag => "#{s.version}" }
 
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "React-Core"
 
-  if fabric_enabled
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  if new_arch_enabled
+    s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "ConicGradientPackageClassic-Swift.h",
       # This is handy when we want to detect if new arch is enabled in Swift code
@@ -37,17 +30,16 @@ Pod::Spec.new do |s|
       # #endif
       "OTHER_SWIFT_FLAGS" => "-DCONIC_GRADIENT_PACKAGE_CLASSIC_NEW_ARCH_ENABLED"
     }
-
-    s.dependency "React-RCTFabric"
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
   else
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "ConicGradientPackageClassic-Swift.h"
     }
   end
+  
+  # Install all React Native dependencies (RN >= 0.71 must be used)
+  #
+  # check source code for more context
+  # https://github.com/facebook/react-native/blob/0.71-stable/scripts/react_native_pods.rb#L172#L180
+  install_modules_dependencies(s)
 end

--- a/conic-gradient-package/ConicGradientPackage.podspec
+++ b/conic-gradient-package/ConicGradientPackage.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name            = "ConicGradientPackage"
@@ -16,16 +16,9 @@ Pod::Spec.new do |s|
   s.source          = { :git => package["repository"], :tag => "#{s.version}" }
 
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "React-Core"
 
-  if fabric_enabled
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  if new_arch_enabled
+    s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "ConicGradientPackage-Swift.h",
       # This is handy when we want to detect if new arch is enabled in Swift code
@@ -37,17 +30,16 @@ Pod::Spec.new do |s|
       # #endif
       "OTHER_SWIFT_FLAGS" => "-DCONIC_GRADIENT_PACKAGE_NEW_ARCH_ENABLED"
     }
-
-    s.dependency "React-RCTFabric"
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
   else
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "ConicGradientPackage-Swift.h"
     }
   end
+  
+  # Install all React Native dependencies (RN >= 0.71 must be used)
+  #
+  # check source code for more context
+  # https://github.com/facebook/react-native/blob/0.71-stable/scripts/react_native_pods.rb#L172#L180
+  install_modules_dependencies(s)
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,35 +1,41 @@
 PODS:
   - AppInfoPackage (0.0.1):
-    - RCT-Folly
+    - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Codegen
     - React-Core
+    - React-RCTFabric
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - AppInfoPackageClassic (0.0.1):
-    - RCT-Folly
+    - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Codegen
     - React-Core
+    - React-RCTFabric
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - ConicGradientPackage (0.0.1):
-    - RCT-Folly
+    - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Codegen
     - React-Core
     - React-RCTFabric
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - ConicGradientPackageClassic (0.0.1):
-    - RCT-Folly
+    - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Codegen
     - React-Core
     - React-RCTFabric
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.71.1)
@@ -108,39 +114,43 @@ PODS:
   - hermes-engine/Pre-built (0.71.0-rc.5)
   - libevent (2.1.12)
   - NativeListPackage (0.0.1):
-    - RCT-Folly
+    - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Codegen
     - React-Core
     - React-RCTFabric
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - NativeListPackageClassic (0.0.1):
-    - RCT-Folly
+    - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Codegen
     - React-Core
     - React-RCTFabric
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - OpenSSL-Universal (1.1.1100)
   - RangeSliderPackage (0.0.1):
     - RangeUISlider (~> 3.0)
-    - RCT-Folly
+    - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Codegen
     - React-Core
     - React-RCTFabric
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - RangeSliderPackageClassic (0.0.1):
     - RangeUISlider (~> 3.0)
-    - RCT-Folly
+    - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Codegen
     - React-Core
     - React-RCTFabric
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - RangeUISlider (3.1.0)
   - RCT-Folly (2021.07.22.00):
@@ -819,32 +829,40 @@ PODS:
     - React-RCTFabric
     - ReactCommon/turbomodule/core
   - SaveFilePickerPackage (0.0.1):
-    - RCT-Folly
+    - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Codegen
     - React-Core
+    - React-RCTFabric
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - SaveFilePickerPackageClassic (0.0.1):
-    - RCT-Folly
+    - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Codegen
     - React-Core
+    - React-RCTFabric
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - ScreenOrientationPackage (0.0.1):
-    - RCT-Folly
+    - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Codegen
     - React-Core
+    - React-RCTFabric
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - ScreenOrientationPackageClassic (0.0.1):
-    - RCT-Folly
+    - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
     - React-Codegen
     - React-Core
+    - React-RCTFabric
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
@@ -1057,12 +1075,12 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  AppInfoPackage: 28a53b52304945861f265c1025379ada8e709b31
-  AppInfoPackageClassic: c8fb9a0e1bfc582460ee8a9898b2cd9f33182794
+  AppInfoPackage: 391a800e59d0939b5842dab56bf50e829140e02b
+  AppInfoPackageClassic: 8c88e98936ff15812dec8827e74ac4aff7cc7156
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  ConicGradientPackage: a6fb356446b4cdfd69325ae6e8c46982eae8cba2
-  ConicGradientPackageClassic: 2245c3f981761a6f1808a3fcc5d099227cc7356b
+  ConicGradientPackage: 62628f7e2ad742d6c92e03fdaadb5755f74e5177
+  ConicGradientPackageClassic: 582c3fb7e22fdba11e735246af10bf1be0abf47f
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: ad72713385db5289b19f1ead07e8e4aa26dcb01d
   FBReactNativeSpec: 06fc2a521838dc240b499699d43467b071c66908
@@ -1079,11 +1097,11 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: a5d6597b0258a8a6fd737e4b40eeac47278610c4
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  NativeListPackage: 978d9f79f3da69cc25ed3a3e2715c5b5931167a9
-  NativeListPackageClassic: 22bd6d4b622fa0779d2f0ca63ffe5398ea98c3e8
+  NativeListPackage: b682589a8809a24a09817adcd7368e15524628a8
+  NativeListPackageClassic: 515d4c257146ccfd37e7b529a466f0020c48ccd2
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  RangeSliderPackage: b35bcd58b72dc683bf3ea54cc6303654d25df3d8
-  RangeSliderPackageClassic: 25fa2a4902d7243dec4c76064a0130d2f2c29588
+  RangeSliderPackage: f08434f60f21956c56a06847d42aaee076de3442
+  RangeSliderPackageClassic: ac9aa9dd7b9637114543d760702cb461d8630614
   RangeUISlider: bb1a82942ef5b6315bd8bf1c12a6b953f0ed02e8
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: fd4d923b964658aa0c4091a32c8b2004c6d9e3a6
@@ -1118,10 +1136,10 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 311feb67600774723fe10eb8801d3138cae9ad67
   ReactCommon: 03be76588338a27a88d103b35c3c44a3fd43d136
   RNScreens: a838934f2f0d915c8a756409d674a862b70b1677
-  SaveFilePickerPackage: 843cdfbfb4e52740e9dfd5ff55152b6b4e1006b9
-  SaveFilePickerPackageClassic: f3d8645212d871a53fb7f318aa732134697e1964
-  ScreenOrientationPackage: 711d8108aadb3676dabbc5bc6f6a69f69a994aa0
-  ScreenOrientationPackageClassic: 7ae7379a2d93cb00f6590d4055175e2f2ccc7205
+  SaveFilePickerPackage: 26ab81819e37627ce19ee75cca5896883947ae8f
+  SaveFilePickerPackageClassic: 4eea2ba8994d9b2d39f34aaa3e820de4c7abdc71
+  ScreenOrientationPackage: c60f5022840edd8e0773a356fd8860f96d1d7caa
+  ScreenOrientationPackageClassic: 81a3ee362a5097f2dddb8697f169b4c2e361d4ae
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 921eb014669cf9c718ada68b08d362517d564e0c
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/native-list-package-classic/NativeListPackageClassic.podspec
+++ b/native-list-package-classic/NativeListPackageClassic.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name            = "NativeListPackageClassic"
@@ -16,16 +16,9 @@ Pod::Spec.new do |s|
   s.source          = { :git => package["repository"], :tag => "#{s.version}" }
 
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "React-Core"
 
-  if fabric_enabled
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  if new_arch_enabled
+    s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "NativeListPackageClassic-Swift.h",
       # This is handy when we want to detect if new arch is enabled in Swift code
@@ -37,17 +30,16 @@ Pod::Spec.new do |s|
       # #endif
       "OTHER_SWIFT_FLAGS" => "-DNATIVE_LIST_PACKAGE_CLASSIC_NEW_ARCH_ENABLED"
     }
-
-    s.dependency "React-RCTFabric"
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
   else
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "NativeListPackageClassic-Swift.h"
     }
   end
+  
+  # Install all React Native dependencies (RN >= 0.71 must be used)
+  #
+  # check source code for more context
+  # https://github.com/facebook/react-native/blob/0.71-stable/scripts/react_native_pods.rb#L172#L180
+  install_modules_dependencies(s)
 end

--- a/native-list-package/NativeListPackage.podspec
+++ b/native-list-package/NativeListPackage.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name            = "NativeListPackage"
@@ -16,16 +16,9 @@ Pod::Spec.new do |s|
   s.source          = { :git => package["repository"], :tag => "#{s.version}" }
 
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "React-Core"
 
-  if fabric_enabled
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  if new_arch_enabled
+    s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "NativeListPackage-Swift.h",
       # This is handy when we want to detect if new arch is enabled in Swift code
@@ -37,17 +30,16 @@ Pod::Spec.new do |s|
       # #endif
       "OTHER_SWIFT_FLAGS" => "-DNATIVE_LIST_PACKAGE_NEW_ARCH_ENABLED"
     }
-
-    s.dependency "React-RCTFabric"
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
   else
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "NativeListPackage-Swift.h"
     }
   end
+
+  # Install all React Native dependencies (RN >= 0.71 must be used)
+  #
+  # check source code for more context
+  # https://github.com/facebook/react-native/blob/0.71-stable/scripts/react_native_pods.rb#L172#L180
+  install_modules_dependencies(s)
 end

--- a/range-slider-package-classic/RangeSliderPackageClassic.podspec
+++ b/range-slider-package-classic/RangeSliderPackageClassic.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name            = "RangeSliderPackageClassic"
@@ -16,18 +16,11 @@ Pod::Spec.new do |s|
   s.source          = { :git => package["repository"], :tag => "#{s.version}" }
 
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "React-Core"
 
   s.dependency 'RangeUISlider', '~> 3.0'
 
-  if fabric_enabled
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  if new_arch_enabled
+    s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "RangeSliderPackageClassic-Swift.h",
       # This is handy when we want to detect if new arch is enabled in Swift code
@@ -39,17 +32,16 @@ Pod::Spec.new do |s|
       # #endif
       "OTHER_SWIFT_FLAGS" => "-DRANGE_SLIDER_PACKAGE_CLASSIC_NEW_ARCH_ENABLED"
     }
-
-    s.dependency "React-RCTFabric"
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
   else
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "RangeSliderPackageClassic-Swift.h"
     }
   end
+  
+  # Install all React Native dependencies (RN >= 0.71 must be used)
+  #
+  # check source code for more context
+  # https://github.com/facebook/react-native/blob/0.71-stable/scripts/react_native_pods.rb#L172#L180
+  install_modules_dependencies(s)
 end

--- a/range-slider-package/RangeSliderPackage.podspec
+++ b/range-slider-package/RangeSliderPackage.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name            = "RangeSliderPackage"
@@ -16,18 +16,11 @@ Pod::Spec.new do |s|
   s.source          = { :git => package["repository"], :tag => "#{s.version}" }
 
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "React-Core"
 
   s.dependency 'RangeUISlider', '~> 3.0'
 
-  if fabric_enabled
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  if new_arch_enabled
+    s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "RangeSliderPackage-Swift.h",
       # This is handy when we want to detect if new arch is enabled in Swift code
@@ -39,17 +32,16 @@ Pod::Spec.new do |s|
       # #endif
       "OTHER_SWIFT_FLAGS" => "-DRANGE_SLIDER_PACKAGE_NEW_ARCH_ENABLED"
     }
-
-    s.dependency "React-RCTFabric"
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
   else
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "RangeSliderPackage-Swift.h"
     }
   end
+  
+  # Install all React Native dependencies (RN >= 0.71 must be used)
+  #
+  # check source code for more context
+  # https://github.com/facebook/react-native/blob/0.71-stable/scripts/react_native_pods.rb#L172#L180
+  install_modules_dependencies(s)
 end

--- a/save-file-picker-package-classic/SaveFilePickerPackageClassic.podspec
+++ b/save-file-picker-package-classic/SaveFilePickerPackageClassic.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name            = "SaveFilePickerPackageClassic"
@@ -16,16 +16,9 @@ Pod::Spec.new do |s|
   s.source          = { :git => package["repository"], :tag => "#{s.version}" }
 
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "React-Core"
 
-  if fabric_enabled
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  if new_arch_enabled
+    s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "SaveFilePickerPackageClassic-Swift.h",
       # This is handy when we want to detect if new arch is enabled in Swift code
@@ -37,16 +30,16 @@ Pod::Spec.new do |s|
       # #endif
       "OTHER_SWIFT_FLAGS" => "-DSAVE_FILE_PICKER_PACKAGE_CLASSIC_NEW_ARCH_ENABLED"
     }
-
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
   else
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "SaveFilePickerPackageClassic-Swift.h"
     }
   end
+  
+  # Install all React Native dependencies (RN >= 0.71 must be used)
+  #
+  # check source code for more context
+  # https://github.com/facebook/react-native/blob/0.71-stable/scripts/react_native_pods.rb#L172#L180
+  install_modules_dependencies(s)
 end

--- a/save-file-picker-package/SaveFilePickerPackage.podspec
+++ b/save-file-picker-package/SaveFilePickerPackage.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name            = "SaveFilePickerPackage"
@@ -16,16 +16,9 @@ Pod::Spec.new do |s|
   s.source          = { :git => package["repository"], :tag => "#{s.version}" }
 
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "React-Core"
 
-  if fabric_enabled
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  if new_arch_enabled
+    s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "SaveFilePickerPackage-Swift.h",
       # This is handy when we want to detect if new arch is enabled in Swift code
@@ -37,16 +30,16 @@ Pod::Spec.new do |s|
       # #endif
       "OTHER_SWIFT_FLAGS" => "-DSAVE_FILE_PICKER_PACKAGE_NEW_ARCH_ENABLED"
     }
-
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
   else
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "SaveFilePickerPackage-Swift.h"
     }
   end
+  
+  # Install all React Native dependencies (RN >= 0.71 must be used)
+  #
+  # check source code for more context
+  # https://github.com/facebook/react-native/blob/0.71-stable/scripts/react_native_pods.rb#L172#L180
+  install_modules_dependencies(s)
 end

--- a/screen-orientation-package-classic/ScreenOrientationPackageClassic.podspec
+++ b/screen-orientation-package-classic/ScreenOrientationPackageClassic.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name            = "ScreenOrientationPackageClassic"
@@ -16,16 +16,9 @@ Pod::Spec.new do |s|
   s.source          = { :git => package["repository"], :tag => "#{s.version}" }
 
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "React-Core"
 
-  if fabric_enabled
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  if new_arch_enabled
+    s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "ScreenOrientationPackageClassic-Swift.h",
       # This is handy when we want to detect if new arch is enabled in Swift code
@@ -37,16 +30,16 @@ Pod::Spec.new do |s|
       # #endif
       "OTHER_SWIFT_FLAGS" => "-DSCREEN_ORIENTATION_PACKAGE_CLASSIC_NEW_ARCH_ENABLED"
     }
-
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
   else
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "ScreenOrientationPackageClassic-Swift.h"
     }
   end
+  
+  # Install all React Native dependencies (RN >= 0.71 must be used)
+  #
+  # check source code for more context
+  # https://github.com/facebook/react-native/blob/0.71-stable/scripts/react_native_pods.rb#L172#L180
+  install_modules_dependencies(s)
 end

--- a/screen-orientation-package/ScreenOrientationPackage.podspec
+++ b/screen-orientation-package/ScreenOrientationPackage.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name            = "ScreenOrientationPackage"
@@ -16,16 +16,9 @@ Pod::Spec.new do |s|
   s.source          = { :git => package["repository"], :tag => "#{s.version}" }
 
   s.source_files    = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "React-Core"
 
-  if fabric_enabled
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+  if new_arch_enabled
+    s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "ScreenOrientationPackage-Swift.h",
       # This is handy when we want to detect if new arch is enabled in Swift code
@@ -37,16 +30,16 @@ Pod::Spec.new do |s|
       # #endif
       "OTHER_SWIFT_FLAGS" => "-DSCREEN_ORIENTATION_PACKAGE_NEW_ARCH_ENABLED"
     }
-
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
   else
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
       "SWIFT_OBJC_INTERFACE_HEADER_NAME" => "ScreenOrientationPackage-Swift.h"
     }
   end
+  
+  # Install all React Native dependencies (RN >= 0.71 must be used)
+  #
+  # check source code for more context
+  # https://github.com/facebook/react-native/blob/0.71-stable/scripts/react_native_pods.rb#L172#L180
+  install_modules_dependencies(s)
 end


### PR DESCRIPTION
closes #21

- improve Setup sections by adding missing informations about linking the package and codegen
- refactored podspec sections to use new install_modules_dependencies API
- add Kotlin support step in Getting Started