### PR TITLE
fix: range slider bugs

### DIFF
--- a/bridging-tutorial-website/docs/guides/range-slider-view/_ios-objc-viewmanager.mdx
+++ b/bridging-tutorial-website/docs/guides/range-slider-view/_ios-objc-viewmanager.mdx
@@ -68,8 +68,8 @@ RCT_EXPORT_METHOD(setRightKnobValueProgrammatically:(nonnull NSNumber*) reactTag
 
 - (void)sendOnRangeSliderViewValueChangeEventWithMinValue:(double)minValue maxValue:(double)maxValue
 {
-    if (slider.onRangeSliderViewValueChange) {
-        slider.onRangeSliderViewValueChange(@{ @"leftKnobValue": @(minValue), @"rightKnobValue": @(maxValue) });
+    if (sliderView.onRangeSliderViewValueChange) {
+        sliderView.onRangeSliderViewValueChange(@{ @"leftKnobValue": @(minValue), @"rightKnobValue": @(maxValue) });
     }
 }
 

--- a/bridging-tutorial-website/docs/guides/range-slider-view/usage.mdx
+++ b/bridging-tutorial-website/docs/guides/range-slider-view/usage.mdx
@@ -37,7 +37,7 @@ export const RangeSliderScreen: React.FC = () => {
         inactiveColor="gray"
         leftKnobValue={leftKnobValue}
         minValue={0}
-        maxValue={0}
+        maxValue={10}
         onRangeSliderViewBeginDrag={() => {
           console.log('BEGIN_DRAG');
         }}


### PR DESCRIPTION
## Summary
- minValue and maxValue were both 0 leading to the following error: `Exception thrown while executing UI
block: NSLayoutConstraint constant is
not finite!
That's illegal.
constant:nan
firstAnchor:<NSLayoutXAxisAnchor:0x60000
ofe3000
"RightKnob.centerX"
(names:
RightKnob:0x7fc6bc5acfb0)>
secondAnchor:<NSLavoutXAxisAnchor:0x6000
00fe2500
"Bar. trailing" (names:
Bar:0x7fc6bc5abe80>`. This fixes it by setting maxValue to 10 as used in the example repos
- use of undefined value `slider`, which should be `sliderView`