### PR TITLE
refactor: remove repetitive how to

### DIFF
--- a/bridging-tutorial-website/docs/guides/range-slider-view/intro.mdx
+++ b/bridging-tutorial-website/docs/guides/range-slider-view/intro.mdx
@@ -9,9 +9,9 @@ import Result from './_result.mdx'
 In this guide, you'll learn how to:
 
 - integrate native libraries in the react-native library with native code
-- how to bring custom native view to the RN app
-- how to emit events from native view to RN app
-- how to invoke custom commands on the native view
+- bring custom native view to the RN app
+- emit events from native view to RN app
+- invoke custom commands on the native view
 
 ### Difficulty
 

--- a/bridging-tutorial-website/docs/guides/save-file-picker-module/intro.mdx
+++ b/bridging-tutorial-website/docs/guides/save-file-picker-module/intro.mdx
@@ -8,9 +8,9 @@ import Result from './_result.mdx'
 
 In this guide, you'll learn how to:
 
-- how to write native module with callback-response method
-- how to write native module with promise-response method
-- how to use platform UI functionality invoked by native module function call
+- write native module with callback-response method
+- write native module with promise-response method
+- use platform UI functionality invoked by native module function call
 
 ### Difficulty
 

--- a/bridging-tutorial-website/docs/guides/screen-orientation-module/intro.mdx
+++ b/bridging-tutorial-website/docs/guides/screen-orientation-module/intro.mdx
@@ -8,9 +8,9 @@ import Result from './_result.mdx'
 
 In this guide, you'll learn how to:
 
-- how to emit events from a native module to the JS code
-- how to subscribe a native module to the events provided by the OS
-- how to export constants from a native module to the JS code
+- emit events from a native module to the JS code
+- subscribe a native module to the events provided by the OS
+- export constants from a native module to the JS code
 
 ### Difficulty
 


### PR DESCRIPTION
## Summary
The line already include `how to` at the end. There is no need to repeat it on every item