### PR TITLE
fix : codegen:ios command

### DIFF
--- a/bridging-tutorial-website/docs/getting-started.mdx
+++ b/bridging-tutorial-website/docs/getting-started.mdx
@@ -157,7 +157,7 @@ module.exports = {
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
 +   "codegen:android": "./android/gradlew -p android generateCodegenArtifactsFromSchema",
-+   "codegen:ios": "node node_modules/react-native/scripts/generate-codegen-artifacts.js --path . --outputPath ./ios"
++   "codegen:ios": "node node_modules/react-native/scripts/generate-codegen-artifacts.js --path . --targetPlatform ios --outputPath ./ios"
   },
 }
 ```


### PR DESCRIPTION
in react native 0.74.x can't generate ios build file without targetPlatform cli

<img width="702" alt="image" src="https://github.com/mateusz1913/rnbridgingtutorial/assets/58166091/99de232c-d79c-4b88-8f6a-f2d1950e5930">
